### PR TITLE
Fix: Improve database connection error handling and health check

### DIFF
--- a/src/common/database.py
+++ b/src/common/database.py
@@ -5,7 +5,10 @@ import os
 # Load environment variables from .env file
 load_dotenv()
 # Database connection URL from environment variable
-DATABASE_URL = os.getenv('DATABASE_URL', "postgresql://postgres:huzKZXKRlfXQeWveALbXWcnyPKHypaRr@nozomi.proxy.rlwy.net:15606/railway")
+DATABASE_URL = os.getenv('DATABASE_URL')
+
+if DATABASE_URL is None:
+    raise ValueError("DATABASE_URL environment variable not set. Please configure it before running the application.")
 
 # Initialize the database connection
 database = Database(DATABASE_URL)


### PR DESCRIPTION
Modified application startup in `main.py`:
- Initialize an `app.state.db_connected` flag.
- Wrap database connection attempts in a try-except block.
- If connection fails (e.g., due to invalid credentials, host unreachable), log the error and set `app.state.db_connected` to `False`, allowing the application to start in a degraded state instead of crashing.

Updated `/health` endpoint in `src/common/routes.py`:
- Check `request.app.state.db_connected`.
- Return 200 OK with "database": "connected" if connection was successful.
- Return 503 Service Unavailable with "database": "disconnected" if connection failed during startup.

This allows the application to provide a more accurate health status regarding its database connectivity, especially in cases of misconfiguration or temporary database issues.